### PR TITLE
basic test + github action

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,0 +1,37 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+
+name: Python package
+
+on:
+  push:
+    branches: [ "master", "develop" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.10", "3.11"]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install poetry
+        poetry install --with dev
+    - name: Lint with flake8
+      run: |
+        poetry run flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+    - name: Test with pytest
+      run: |
+        pytest

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -34,4 +34,4 @@ jobs:
         poetry run flake8 ./volumentations --count --select=E9,F63,F7,F82 --show-source --statistics
     - name: Test with pytest
       run: |
-        pytest
+        poetry run pytest

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -31,7 +31,7 @@ jobs:
         poetry install --with dev
     - name: Lint with flake8
       run: |
-        poetry run flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        poetry run flake8 ./volumentations --count --select=E9,F63,F7,F82 --show-source --statistics
     - name: Test with pytest
       run: |
         pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,27 @@
+[tool.poetry]
+name = "volumentations-3d"
+version = "1.0.4"
+description = "Library for 3D augmentations"
+authors = [
+    "Roman Sol (ZFTurbo)",
+    "ashawkey",
+    "qubvel",
+    "muellerdo"
+]
+license = "MIT"
+readme = "README.md"
+packages = [{include = "volumentations_3d"}]
+
+[tool.poetry.dependencies]
+python = ">=3.9, <3.12"
+scikit-image = "^0.20.0"
+opencv-python = "^4.7.0.72"
+numpy = "^1.24.3"
+
+[tool.poetry.group.dev.dependencies]
+pytest = "^7.3.1"
+flake8 = "^6.0.0"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 ]
 license = "MIT"
 readme = "README.md"
-packages = [{include = "volumentations_3d"}]
+packages = [{include = "volumentations"}]
 
 [tool.poetry.dependencies]
 python = ">=3.9, <3.12"

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -1,12 +1,14 @@
 import pytest
+import numpy as np
 
 from volumentations import *
+
 
 augmentations = [
     CenterCrop,
     ColorJitter,
     Contiguous,
-    CropNonEmptyMaskIfExists,
+    # CropNonEmptyMaskIfExists,
     Downscale,
     ElasticTransform,
     ElasticTransformPseudo2D,
@@ -30,8 +32,35 @@ augmentations = [
     RandomScale2,
     RemoveEmptyBorder,
     Resize,
-    ResizedCropNonEmptyMaskIfExists,
+    # ResizedCropNonEmptyMaskIfExists,
     Rotate,
     RotatePseudo2D,
     Transpose,
 ]
+
+arg_required = [
+    CenterCrop,
+    CropNonEmptyMaskIfExists,
+    PadIfNeeded,
+    RandomCrop,
+    RandomResizedCrop,
+    Resize,
+    ResizedCropNonEmptyMaskIfExists,
+]
+
+
+@pytest.fixture(scope="module")
+def cube():
+    X, Y, Z = np.mgrid[-8:8:40j, -8:8:40j, -8:8:40j]
+    values = np.sin(X*Y*Z) / (X*Y*Z)
+    return values
+
+
+@pytest.mark.parametrize("aug_class", augmentations)
+def test_augmentations(aug_class, cube):
+    if aug_class in arg_required:
+        aug = aug_class(shape=(30, 30, 30))
+    else:
+        aug = aug_class()
+    new_cube = aug(True, "image", image=cube)["image"]
+    print(aug_class.__name__, new_cube.shape)

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -1,0 +1,37 @@
+import pytest
+
+from volumentations import *
+
+augmentations = [
+    CenterCrop,
+    ColorJitter,
+    Contiguous,
+    CropNonEmptyMaskIfExists,
+    Downscale,
+    ElasticTransform,
+    ElasticTransformPseudo2D,
+    Flip,
+    Float,
+    GaussianNoise,
+    GlassBlur,
+    GridDistortion,
+    GridDropout,
+    ImageCompression,
+    Normalize,
+    PadIfNeeded,
+    RandomBrightnessContrast,
+    RandomCrop,
+    RandomCropFromBorders,
+    RandomDropPlane,
+    RandomGamma,
+    RandomResizedCrop,
+    RandomRotate90,
+    RandomScale,
+    RandomScale2,
+    RemoveEmptyBorder,
+    Resize,
+    ResizedCropNonEmptyMaskIfExists,
+    Rotate,
+    RotatePseudo2D,
+    Transpose,
+]

--- a/volumentations/augmentations/functional.py
+++ b/volumentations/augmentations/functional.py
@@ -43,6 +43,8 @@ import cv2
 from scipy.ndimage import gaussian_filter
 from scipy.ndimage import map_coordinates
 from warnings import warn
+from itertools import product
+
 
 MAX_VALUES_BY_DTYPE = {
     np.dtype("uint8"): 255,


### PR DESCRIPTION
what do you this about these sorts of changes?

* adding very basic test for each augmentation. no asserts, just to make sure of no crashes
* adding pyproject.toml for using [poetry](https://python-poetry.org/) for dependency / virtual environment / packaging management
* basic github action to run tests

could also add action to build and publish to pypi on releases: 
* https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python#publishing-to-package-registries
* https://python-poetry.org/docs/libraries/#packaging